### PR TITLE
Config for default image in open graph

### DIFF
--- a/at_opengraph.php
+++ b/at_opengraph.php
@@ -68,6 +68,10 @@ class At_OpenGraph {
 			);
 		}
 		
+		if (isset($this->settings['opengraph_default_image'])) {
+			$images[] = $this->settings['opengraph_default_image'];
+		}
+		
 		$this->images = $images;
 	}
 	


### PR DESCRIPTION
It is awesome to load first image in the page, but some pages may not have images. Hence I created the "opengraph_default_image" setting and push into the array of images in case there is no images.
